### PR TITLE
Modify a hash in place and freeze strings to reduce allocations.

### DIFF
--- a/lib/ruport/data/record.rb
+++ b/lib/ruport/data/record.rb
@@ -55,10 +55,10 @@ module Ruport::Data
       case(data)
       when Array
         @attributes = options[:attributes] || (0...data.length).to_a
-        @data = @attributes.inject({}) { |h,a| h.merge(a => data.shift) }
+        @data = @attributes.each_with_object({}) { |a, h| h[a.freeze] = data.shift }
       when Hash
-        @data = data.dup
-        @attributes = options[:attributes] || data.keys
+        @data = data
+        @attributes = options[:attributes] || @data.keys
       end
     end        
     


### PR DESCRIPTION
In the case of a data array:
Each `h.merge` with a single element assignment was duplicating the
hash and allocating a string for each attribute used as a key. We can
instead allocate a single hash, modify it in place and freeze the objects
used as keys in the hash.  If ruby 2.1+ and they're strings, we won't
need to dup them when used as keys.

In the case of a data hash:
The hash has been dup'd once, there's no reason to duplicate it again.

In a simplified use case, Ruport::Data::Record.new with a data array
is now 29 times faster.  With a data hash, it's now 2 times faster.

Benchmark:

```
Calculating -------------------------------------
Existing Ruport::Data::Record, array
                       150.000  i/100ms
New Ruport::Data::Record, array
                         4.628k i/100ms
-------------------------------------------------
Existing Ruport::Data::Record, array
                          1.646k (±28.7%) i/s -      7.350k
New Ruport::Data::Record, array
                         48.651k (±25.2%) i/s -    222.144k

Comparison:
New Ruport::Data::Record, array:    48650.7 i/s
Existing Ruport::Data::Record, array:     1646.0 i/s - 29.56x slower

Calculating -------------------------------------
Existing Ruport::Data::Record, hash
                         2.361k i/100ms
New Ruport::Data::Record, hash
                         4.830k i/100ms
-------------------------------------------------
Existing Ruport::Data::Record, hash
                         24.867k (±25.9%) i/s -    113.328k
New Ruport::Data::Record, hash
                         52.123k (±23.4%) i/s -    241.500k

Comparison:
New Ruport::Data::Record, hash:    52122.7 i/s
Existing Ruport::Data::Record, hash:    24866.9 i/s - 2.10x slower

true
true
true
true
```

SCRIPT:

``` ruby
require "benchmark/ips"

data_hash         = {"resource_name"=>"fakevm0221", "max_cpu_usage_rate_average"=>25.125, "cpu_usage_rate_average"=>23.5248523543932, "cpu_usagemhz_rate_average"=>1026.21051934428, "max_mem_usage_absolute_average"=>41.5859375, "mem_usage_absolute_average"=>38.9171299730112, "derived_memory_used"=>199.255705461817, "resource_type"=>"VmOrTemplate", "resource_id"=>1221, "id"=>30907, "vm.v_annotation"=>nil, "vm.cpu_total_cores"=>1, "vm.cpu_shares_level"=>nil, "vm.mem_cpu"=>512, "vm.memory_reserve"=>nil, "vm.memory_shares_level"=>nil, "vm.provisioned_storage"=>11022630912, "vm.used_disk_storage"=>10485760000, "vm.v_total_snapshots"=>1, "vm.disk_1_disk_type"=>"thin", "vm.disk_1_mode"=>"persistent", "vm.disk_1_size"=>10485760000, "vm.disk_1_size_on_disk"=>nil, "vm.disk_1_used_percent_of_provisioned"=>0.0, "vm.disk_2_disk_type"=>nil, "vm.disk_2_mode"=>nil, "vm.disk_2_size"=>nil, "vm.disk_2_size_on_disk"=>nil, "vm.disk_2_used_percent_of_provisioned"=>nil, "vm.disk_3_disk_type"=>nil, "vm.disk_3_mode"=>nil, "vm.disk_3_size"=>nil, "vm.disk_3_size_on_disk"=>nil, "vm.disk_3_used_percent_of_provisioned"=>nil, "vm.disk_4_disk_type"=>nil, "vm.disk_4_mode"=>nil, "vm.disk_4_size"=>nil, "vm.disk_4_size_on_disk"=>nil, "vm.disk_4_used_percent_of_provisioned"=>nil, "vm.disk_5_disk_type"=>nil, "vm.disk_5_mode"=>nil, "vm.disk_5_size"=>nil, "vm.disk_5_size_on_disk"=>nil, "vm.disk_5_used_percent_of_provisioned"=>nil, "vm.disk_6_disk_type"=>nil, "vm.disk_6_mode"=>nil, "vm.disk_6_size"=>nil, "vm.disk_6_size_on_disk"=>nil, "vm.disk_6_used_percent_of_provisioned"=>nil, "managed.folder_path_yellow"=>"Datacenters", "host.name"=>"fakehost025", "ems_cluster.name"=>"Default5"}
options_for_hash  = {:attributes=>["resource_name", "max_cpu_usage_rate_average", "cpu_usage_rate_average", "cpu_usagemhz_rate_average", "max_mem_usage_absolute_average", "mem_usage_absolute_average", "derived_memory_used", "resource_type", "resource_id", "id", "vm.v_annotation", "vm.cpu_total_cores", "vm.cpu_shares_level", "vm.mem_cpu", "vm.memory_reserve", "vm.memory_shares_level", "vm.provisioned_storage", "vm.used_disk_storage", "vm.v_total_snapshots", "vm.disk_1_disk_type", "vm.disk_1_mode", "vm.disk_1_size", "vm.disk_1_size_on_disk", "vm.disk_1_used_percent_of_provisioned", "vm.disk_2_disk_type", "vm.disk_2_mode", "vm.disk_2_size", "vm.disk_2_size_on_disk", "vm.disk_2_used_percent_of_provisioned", "vm.disk_3_disk_type", "vm.disk_3_mode", "vm.disk_3_size", "vm.disk_3_size_on_disk", "vm.disk_3_used_percent_of_provisioned", "vm.disk_4_disk_type", "vm.disk_4_mode", "vm.disk_4_size", "vm.disk_4_size_on_disk", "vm.disk_4_used_percent_of_provisioned", "vm.disk_5_disk_type", "vm.disk_5_mode", "vm.disk_5_size", "vm.disk_5_size_on_disk", "vm.disk_5_used_percent_of_provisioned", "vm.disk_6_disk_type", "vm.disk_6_mode", "vm.disk_6_size", "vm.disk_6_size_on_disk", "vm.disk_6_used_percent_of_provisioned", "managed.folder_path_yellow", "host.name", "ems_cluster.name", "max_cpu_usage_rate_average__max", "cpu_usage_rate_average__avg", "cpu_usagemhz_rate_average__avg", "max_mem_usage_absolute_average__max", "mem_usage_absolute_average__avg", "derived_memory_used__avg", "managed.department"]}
data_array        = ["Default10", "Datacenters", "fakevm0500", nil, 1, nil, 512, nil, nil, 26.512, 24.015380350142365, 1047.6085277860532, 42.7734375, 39.42654082373073, 201.86388901750163, 11022630912, 10485760000, 1, "thin", "persistent", 10485760000, nil, 0.0, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, "\xFF", "fakehost046", "VmOrTemplate", 1500]
options_for_array = {:attributes=>["ems_cluster.name", "managed.folder_path_yellow", "resource_name", "vm.v_annotation", "vm.cpu_total_cores", "vm.cpu_shares_level", "vm.mem_cpu", "vm.memory_reserve", "vm.memory_shares_level", "max_cpu_usage_rate_average__max", "cpu_usage_rate_average__avg", "cpu_usagemhz_rate_average__avg", "max_mem_usage_absolute_average__max", "mem_usage_absolute_average__avg", "derived_memory_used__avg", "vm.provisioned_storage", "vm.used_disk_storage", "vm.v_total_snapshots", "vm.disk_1_disk_type", "vm.disk_1_mode", "vm.disk_1_size", "vm.disk_1_size_on_disk", "vm.disk_1_used_percent_of_provisioned", "vm.disk_2_disk_type", "vm.disk_2_mode", "vm.disk_2_size", "vm.disk_2_size_on_disk", "vm.disk_2_used_percent_of_provisioned", "vm.disk_3_disk_type", "vm.disk_3_mode", "vm.disk_3_size", "vm.disk_3_size_on_disk", "vm.disk_3_used_percent_of_provisioned", "vm.disk_4_disk_type", "vm.disk_4_mode", "vm.disk_4_size", "vm.disk_4_size_on_disk", "vm.disk_4_used_percent_of_provisioned", "vm.disk_5_disk_type", "vm.disk_5_mode", "vm.disk_5_size", "vm.disk_5_size_on_disk", "vm.disk_5_used_percent_of_provisioned", "vm.disk_6_disk_type", "vm.disk_6_mode", "vm.disk_6_size", "vm.disk_6_size_on_disk", "vm.disk_6_used_percent_of_provisioned", "managed.department", "host.name", "resource_type", "resource_id"]}

module Ruport
  module Data
    class RecordNew
      include Enumerable

      def attributes
        @attributes.dup
      end
      attr_reader :data

      def initialize(data,options={})
        data = data.dup
        case(data)
        when Array
          @attributes = options[:attributes] || (0...data.length).to_a
          @data = @attributes.each_with_object({}) { |a, h| h[a.freeze] = data.shift }
        when Hash
          @data = data
          @attributes = options[:attributes] || @data.keys
        end
      end
    end
  end
end

module Ruport
  module Data
    class Record
      include Enumerable
      def attributes
        @attributes.dup
      end
      attr_reader :data

      def initialize(data,options={})
        data = data.dup
        case(data)
        when Array
          @attributes = options[:attributes] || (0...data.length).to_a
          @data = @attributes.inject({}) { |h,a| h.merge(a => data.shift) }
        when Hash
          @data = data.dup
          @attributes = options[:attributes] || data.keys
        end
      end
    end
  end
end

Benchmark.ips do |x|
  x.report("Existing Ruport::Data::Record, array") { Ruport::Data::Record.new(data_array, options_for_array) }
  x.report("New Ruport::Data::Record, array")      { Ruport::Data::RecordNew.new(data_array, options_for_array) }
  x.compare!
end

Benchmark.ips do |x|
  x.report("Existing Ruport::Data::Record, hash") { Ruport::Data::Record.new(data_hash, options_for_hash) }
  x.report("New Ruport::Data::Record, hash")      { Ruport::Data::RecordNew.new(data_hash, options_for_hash) }
  x.compare!
end

old_hash = Ruport::Data::Record.new(data_hash, options_for_hash)
new_hash = Ruport::Data::RecordNew.new(data_hash, options_for_hash)
puts old_hash.data == new_hash.data
puts old_hash.attributes == new_hash.attributes

old_array = Ruport::Data::Record.new(data_array, options_for_array)
new_array = Ruport::Data::RecordNew.new(data_array, options_for_array)
puts old_array.data == new_array.data
puts old_array.attributes == new_array.attributes
```
